### PR TITLE
Fix for copying biglinux logo files to gnome in hooks

### DIFF
--- a/usr/share/libalpm/scripts/biglinux-text-rounded
+++ b/usr/share/libalpm/scripts/biglinux-text-rounded
@@ -4,6 +4,6 @@
 # Verifica se os arquivos originais existem
 if [ -f "/usr/share/icons/manjaro/manjarolinux-text-rounded.svg" ] && [ -f "/usr/share/icons/manjaro/manjarolinux-text-dark-rounded.svg" ]; then
   # Realiza a substituição dos arquivos
-  mv -f /usr/share/icons/manjaro/manjarolinux-text-rounded.svg /usr/share/icons/manjaro/biglinux-text-rounded.svg
-  mv -f /usr/share/icons/manjaro/manjarolinux-text-dark-rounded.svg /usr/share/icons/manjaro/biglinux-text-dark-rounded.svg
+  mv -f /usr/share/icons/manjaro/biglinux-text-rounded.svg /usr/share/icons/manjaro/manjarolinux-text-rounded.svg
+  mv -f /usr/share/icons/manjaro/biglinux-text-dark-rounded.svg /usr/share/icons/manjaro/manjarolinux-text-dark-rounded.svg
 fi


### PR DESCRIPTION
Fix for copying biglinux logo files to gnome in hooks